### PR TITLE
Match is now has a property to return the sentence

### DIFF
--- a/grammarbot/__init__.py
+++ b/grammarbot/__init__.py
@@ -60,6 +60,13 @@ class GrammarBotMatch:
         return self._match_json["rule"]["category"]["id"]
 
     @property
+    def category(self) -> str:
+        """
+        Returns the sentence the match is referring to.
+        """
+        return self._match_json["sentence"]
+
+    @property
     def replacement_offset(self) -> int:
         """
         Gives the offset at which the replacement should be made.


### PR DESCRIPTION
When playing with grammarbot for Python I noticed that the sentence was not returned in the match object. This makes it difficult to identify the sentence the match is referring to. So I have updated the object without diving in to the match json object. So I created a shortcut property like the rest of this object.